### PR TITLE
Use the configeration to generate the language picker.

### DIFF
--- a/themes/vulkan/templates/layout/05_page.php
+++ b/themes/vulkan/templates/layout/05_page.php
@@ -21,9 +21,17 @@
 
                 <!-- Language picker -->
                 <div class="language-picker">
-                    <a href="/Introduction">English</a>
-                    /
-                    <a href="/fr/Introduction">Français</a>
+                <?php
+                $language_pickers = array();
+                foreach($params['languages'] as $lang => $lang_name) {
+                    if ($lang === $params['language']) {
+                        $language_pickers[] = '<a href="/Introduction">' . $lang_name . '</a>';
+                    } else {
+                        $language_pickers[] = '<a href="/' . $lang . '/Introduction">' . $lang_name . '</a>';
+                    }
+                }
+                echo implode(' / ', $language_pickers);
+                ?>
                 </div>
 
                 <!-- Navigation -->


### PR DESCRIPTION
Currently the content of the "language-picker" is hard-coded in the theme code. This PR use the `languages` option to generate the contents, so translations of new languages will be easier to be added.

This is the effect with `"languages": {"en": "English", "fr": "Français", "zh": "中文"}`:

![图片](https://user-images.githubusercontent.com/31474766/125200225-aa028700-e29c-11eb-854b-06b1aeff06e9.png)
